### PR TITLE
Ds 58 url modal bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # QuickR
 
 ## Description
+
 This application will let users save QR Codes, and generate new ones from any url. They will also have the ability to organize codes with a folder system.
 
 ## Project Requirements
@@ -10,8 +11,8 @@ This application will let users save QR Codes, and generate new ones from any ur
 ### Project Setup
 
 - Install required packages
-    - Navigate project's root directory
-    - Type and run `yarn install`
+  - Navigate project's root directory
+  - Type and run `yarn install`
 
 ### Running the Project
 
@@ -28,25 +29,20 @@ This application will let users save QR Codes, and generate new ones from any ur
 ## Deployment Instructions
 
 ## App Fuctionality Testing Routine
-1. Add Folder 
-2. Add Folder w/ Links
-3. Add Links inside add folder page
-4. Add links to current folders with picker 
-5. Edit name, description, and color of current folders
-6. Edit name, description, and color of newly made folders
-7. Add links inside edit page of current folders
-8. Add links inside edit page of newly made folders
-9. Delete current folders
-10. Delete newly made folders 
 
+1. Add Folder (pass)
+2. Add Folder w/ Links (pass)
+3. Add Links inside add folder page (same as 2)
+4. Add links to current folders with picker (pass)
+5. Edit name, description, and color of current folders (pass)
+6. Edit name, description, and color of newly made folders (pass)
+7. Add links inside edit page of current folders ( fail - error alert for empty field inputs)
+8. Add links inside edit page of newly made folders ( fail - same input error alert)
+9. Delete current folders (pass)
+10. Delete newly made folders (pass)
 
 ## Features to be added in testing routine
+
 11. Edit URL
 12. Delete URL
 13. Scan URL
-
-
-
-
-
-

--- a/components/UrlModal/UrlModal.js
+++ b/components/UrlModal/UrlModal.js
@@ -1,4 +1,4 @@
-import { Pressable, Modal, Image } from "react-native";
+import { Pressable, Modal, Image, Alert } from "react-native";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { addUrlToFolder } from "../../redux/folderSlice";
@@ -33,6 +33,7 @@ import {
   GradientBackground,
   CloseContainer,
 } from "../AddOrScanModal/styles";
+import { selectValidFolderToast } from "../../utils/toastNote";
 
 function UrlModal({ picker, setNewLinks, newLinks }) {
   const dispatch = useDispatch();
@@ -89,6 +90,11 @@ function UrlModal({ picker, setNewLinks, newLinks }) {
       },
     ]);
     dispatch(toggleAddUrlModal());
+
+    // fields should clear upon save
+    setInputName("");
+    setInputUrl("");
+    setInputDescription("");
   };
 
   // ------------------------------------------------------------------------RENDERED FOLDERS IN PICKER
@@ -126,6 +132,14 @@ function UrlModal({ picker, setNewLinks, newLinks }) {
         </PickerContainer>
       </FolderSection>
     );
+  };
+
+  const validateFolderSelection = () => {
+    if (currentEditFolder || !picker) {
+      currentEditFolder ? finalSubmissionRedux() : finalSubmissionLocal();
+    } else {
+      selectValidFolderToast();
+    }
   };
 
   const renderModal = () => {
@@ -193,13 +207,7 @@ function UrlModal({ picker, setNewLinks, newLinks }) {
                   {picker ? showFolderPicker() : null}
 
                   <BtnFooter>
-                    <SaveBtnWrapper
-                      onPress={() =>
-                        currentEditFolder
-                          ? finalSubmissionRedux()
-                          : finalSubmissionLocal()
-                      }
-                    >
+                    <SaveBtnWrapper onPress={() => validateFolderSelection()}>
                       <SaveText>Save</SaveText>
                     </SaveBtnWrapper>
                   </BtnFooter>

--- a/components/UrlModal/UrlModal.js
+++ b/components/UrlModal/UrlModal.js
@@ -53,6 +53,11 @@ function UrlModal({ picker, setNewLinks, newLinks }) {
   const folderNamesArray = Object.keys(folderData);
 
   const finalSubmissionRedux = () => {
+    // fields should clear upon save
+    setInputName("");
+    setInputUrl("");
+    setInputDescription("");
+
     dispatch(
       addUrlToFolder({
         addedLink: {

--- a/components/folder/AddFolderPage/AddFolderPage.js
+++ b/components/folder/AddFolderPage/AddFolderPage.js
@@ -39,9 +39,7 @@ import { useSelector, useDispatch } from "react-redux";
 import AddOrScanModal from "../../AddOrScanModal/AddOrScanModal";
 import ColorPicker from "../../ColorPicker/ColorPicker";
 import UrlModal from "../../UrlModal/UrlModal";
-import {
-  addNewFolder,
-} from "../../../redux/folderSlice";
+import { addNewFolder } from "../../../redux/folderSlice";
 import { approvedColors } from "../../../utils/approvedColors";
 
 function AddFolderPage({ navigation }) {
@@ -52,7 +50,6 @@ function AddFolderPage({ navigation }) {
   const folderKeys = useSelector((state) =>
     Object.keys(state.folder.allFolder)
   );
-
 
   const [newLinks, setNewLinks] = useState([]);
   const dispatch = useDispatch();
@@ -117,7 +114,7 @@ function AddFolderPage({ navigation }) {
   const renderLinks = (linksToRender) => {
     return linksToRender?.map((link) => {
       return (
-        <AddedLinkWrapper key={link.name}>
+        <AddedLinkWrapper key={link.id}>
           <AddedLinks>{link.name}</AddedLinks>
           <EditIcon source={editIcon} />
         </AddedLinkWrapper>
@@ -135,7 +132,7 @@ function AddFolderPage({ navigation }) {
           key={color}
           color={color}
         />
-      ); 
+      );
     });
   };
 
@@ -178,7 +175,7 @@ function AddFolderPage({ navigation }) {
             <ColorGridLabel>Folder Color:</ColorGridLabel>
             <CurrentFolderColor folderColor={folderColor} />
           </ColorGridLabelContainer>
-            
+
           <ColorGrid>{pickFolderColor()}</ColorGrid>
         </ColorGridSection>
         {/* ************ Color Picker ************ */}
@@ -186,9 +183,7 @@ function AddFolderPage({ navigation }) {
 
         <LinkWrapper>
           <AddedLinksLabel>Links</AddedLinksLabel>
-          <NewLinks>
-            {renderLinks(newLinks)}
-          </NewLinks>
+          <NewLinks>{renderLinks(newLinks)}</NewLinks>
           <AddLinkBtn
             onPress={() => {
               dispatch(toggleAddOrScanModal());
@@ -202,16 +197,20 @@ function AddFolderPage({ navigation }) {
 
         {/* ------------------Save / Cancel Buttons------------------- */}
         <CreateCancelContainer>
-        <CancelBtn onPress={() => navigation.goBack()}>
-          <CancelText>Cancel</CancelText>
-        </CancelBtn>
-        <CreateFolderBtn onPress={() => createNewFolder()}>
-          <CreateText>Create</CreateText>
-        </CreateFolderBtn>
-      </CreateCancelContainer>
+          <CancelBtn onPress={() => navigation.goBack()}>
+            <CancelText>Cancel</CancelText>
+          </CancelBtn>
+          <CreateFolderBtn onPress={() => createNewFolder()}>
+            <CreateText>Create</CreateText>
+          </CreateFolderBtn>
+        </CreateCancelContainer>
 
         <AddOrScanModal />
-        <UrlModal setNewLinks={setNewLinks} newLinks={newLinks} picker={false} />
+        <UrlModal
+          setNewLinks={setNewLinks}
+          newLinks={newLinks}
+          picker={false}
+        />
       </Container>
     </ScrollView>
   );

--- a/components/folder/EditFolderPage/EditFolderPage.js
+++ b/components/folder/EditFolderPage/EditFolderPage.js
@@ -54,14 +54,16 @@ function EditFolderPage({ navigation, route }) {
 
   const folderToEdit = useSelector((state) => {
     return state.modal.folderToEdit;
-  })
+  });
   const folderKeys = useSelector((state) =>
     Object.keys(state.folder.allFolder)
   );
 
   const currentLinks = useSelector((state) => state.folder.allFolder);
 
-  const currentFolder = useSelector((state) => state.folder.allFolder[folderToEdit]);
+  const currentFolder = useSelector(
+    (state) => state.folder.allFolder[folderToEdit]
+  );
 
   const dispatch = useDispatch();
 
@@ -144,10 +146,9 @@ function EditFolderPage({ navigation, route }) {
           },
           style: "default",
         },
-      ] 
+      ]
     );
   };
-
 
   // ---------------------------------------------------------ON PRESS FUNCTION FOR SAVE BUTTON
 
@@ -165,8 +166,6 @@ function EditFolderPage({ navigation, route }) {
   };
 
   // ---------------------------------------------------------DELETE/SAVE BUTTONS
-
-
 
   const renderEditFolderButtons = () => {
     return (
@@ -186,7 +185,7 @@ function EditFolderPage({ navigation, route }) {
   const renderLinks = (linksToRender) => {
     return linksToRender?.map((link) => {
       return (
-        <AddedLinkWrapper key={link.name}>
+        <AddedLinkWrapper key={link.id}>
           <AddedLinks>{link.name}</AddedLinks>
           <EditIcon source={editIcon} />
         </AddedLinkWrapper>
@@ -247,7 +246,7 @@ function EditFolderPage({ navigation, route }) {
             <ColorGridLabel>Folder Color:</ColorGridLabel>
             <CurrentFolderColor folderColor={folderColor} />
           </ColorGridLabelContainer>
-            
+
           <ColorGrid>{pickFolderColor()}</ColorGrid>
         </ColorGridSection>
         {/* ************ Color Picker ************ */}
@@ -255,9 +254,7 @@ function EditFolderPage({ navigation, route }) {
 
         <LinkWrapper>
           <AddedLinksLabel>Links</AddedLinksLabel>
-          <NewLinks>
-            {renderLinks(currentLinks[folderToEdit]?.items)}
-          </NewLinks>
+          <NewLinks>{renderLinks(currentLinks[folderToEdit]?.items)}</NewLinks>
           <AddLinkBtn
             onPress={() => {
               dispatch(toggleAddOrScanModal());

--- a/utils/toastNote.js
+++ b/utils/toastNote.js
@@ -1,18 +1,33 @@
 import Toast from "react-native-root-toast";
 
- export const runToaster = (deletedFolder) => {
-    let toast = Toast.show(`${deletedFolder} Has Been Deleted`, {
-      duration: 2000,
-      position: 100,
-      shadow: false,
-      backgroundColor: '#363636',
-      textColor: "white",
-      animation: true,
-      hideOnPress: true,
-      delay: 500,
-      opacity: 1,
-    });
+export const runToaster = (deletedFolder) => {
+  let toast = Toast.show(`${deletedFolder} Has Been Deleted`, {
+    duration: 2000,
+    position: 100,
+    shadow: false,
+    backgroundColor: "#363636",
+    textColor: "white",
+    animation: true,
+    hideOnPress: true,
+    delay: 500,
+    opacity: 1,
+  });
 
-    return toast;
-  };
+  return toast;
+};
 
+export const selectValidFolderToast = () => {
+  let toast = Toast.show(`Please select a valid folder.`, {
+    duration: 2000,
+    position: -100,
+    shadow: false,
+    backgroundColor: "#363636",
+    textColor: "white",
+    animation: true,
+    hideOnPress: true,
+    delay: 500,
+    opacity: 1,
+  });
+
+  return toast;
+};


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Implement error handling for input fields when user saves a new URL.
2. Prevent user from saving URL, if they have not selected a valid folder. (with popup toast)
3. Clear out input fields on URL save.
4. Implement proper URL key ID's

## Purpose
App crashed on user saving a URL Modal without valid folder. Terminal also gave a warning on repeated key id's.
Input fields also were populating on previous typed URL values.

Closes #58 