### PR TITLE
Dynamically render folder icons

### DIFF
--- a/components/folder/IndividualFolder/IndividualFolder.js
+++ b/components/folder/IndividualFolder/IndividualFolder.js
@@ -6,13 +6,11 @@ import {
   FolderTitle,
   FolderColorBubble,
   TitleContainer,
-  EditButton,
   FolderInitialElements,
   FolderOpenedElements,
 } from "./styles";
 import { useSelector, useDispatch } from "react-redux";
 import { openAccordion } from "../../../redux/folderSlice";
-import editIcon from "../../../assets/editIcon.png";
 import { setFolderToEdit } from "../../../redux/modalSlice";
 import { MaterialIcons } from "@expo/vector-icons";
 import { MaterialCommunityIcons } from "@expo/vector-icons";

--- a/components/folder/IndividualFolder/IndividualFolder.js
+++ b/components/folder/IndividualFolder/IndividualFolder.js
@@ -7,15 +7,14 @@ import {
   FolderColorBubble,
   TitleContainer,
   EditButton,
-  FolderToggleButton,
   FolderInitialElements,
   FolderOpenedElements,
 } from "./styles";
 import { useSelector, useDispatch } from "react-redux";
 import { openAccordion } from "../../../redux/folderSlice";
 import editIcon from "../../../assets/editIcon.png";
-import upIcon from "../../../assets/upIcon.png";
 import { setFolderToEdit } from "../../../redux/modalSlice";
+import { MaterialIcons } from "@expo/vector-icons";
 
 function IndividualFolder({ folder, folderName, navigation }) {
   const dispatch = useDispatch();
@@ -50,11 +49,19 @@ function IndividualFolder({ folder, folderName, navigation }) {
         <TitleContainer>
           <FolderColorBubble folderColor={folder.folderColor} />
           <FolderTitle>{folderName}</FolderTitle>
-          <Pressable onPress={() => editButtonAction()} hitslop={10}>
-            <EditButton source={editIcon} />
-          </Pressable>
+          {/* only render edit icon if accordion is open */}
+          {accordion[folderName].isAccordionOpen ? (
+            <Pressable onPress={() => editButtonAction()} hitslop={10}>
+              <EditButton source={editIcon} />
+            </Pressable>
+          ) : null}
         </TitleContainer>
-        <FolderToggleButton source={upIcon} />
+        {/* down arrow when folder is closed | up arrow when folder is open */}
+        {accordion[folderName].isAccordionOpen ? (
+          <MaterialIcons name="keyboard-arrow-up" size={24} color="white" />
+        ) : (
+          <MaterialIcons name="keyboard-arrow-down" size={24} color="white" />
+        )}
       </FolderInitialElements>
 
       {showLinks()}

--- a/components/folder/IndividualFolder/IndividualFolder.js
+++ b/components/folder/IndividualFolder/IndividualFolder.js
@@ -15,6 +15,7 @@ import { openAccordion } from "../../../redux/folderSlice";
 import editIcon from "../../../assets/editIcon.png";
 import { setFolderToEdit } from "../../../redux/modalSlice";
 import { MaterialIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 function IndividualFolder({ folder, folderName, navigation }) {
   const dispatch = useDispatch();
@@ -52,15 +53,19 @@ function IndividualFolder({ folder, folderName, navigation }) {
           {/* only render edit icon if accordion is open */}
           {accordion[folderName].isAccordionOpen ? (
             <Pressable onPress={() => editButtonAction()} hitslop={10}>
-              <EditButton source={editIcon} />
+              <MaterialCommunityIcons
+                name="pencil-outline"
+                size={20}
+                color="white"
+              />
             </Pressable>
           ) : null}
         </TitleContainer>
         {/* down arrow when folder is closed | up arrow when folder is open */}
         {accordion[folderName].isAccordionOpen ? (
-          <MaterialIcons name="keyboard-arrow-up" size={24} color="white" />
+          <MaterialIcons name="keyboard-arrow-up" size={30} color="#6F6F6F" />
         ) : (
-          <MaterialIcons name="keyboard-arrow-down" size={24} color="white" />
+          <MaterialIcons name="keyboard-arrow-down" size={30} color="#6F6F6F" />
         )}
       </FolderInitialElements>
 

--- a/components/folder/IndividualFolder/styles.js
+++ b/components/folder/IndividualFolder/styles.js
@@ -35,12 +35,6 @@ export const EditButton = styled.Image`
   width: 20px;
 `;
 
-export const FolderToggleButton = styled.Image`
-  height: 24px;
-  width: 24px;
-  transform: rotateZ(180deg);
-`;
-
 export const FolderInitialElements = styled.View`
   width: ${windowWidth};
   height: 65px;

--- a/components/folder/IndividualFolder/styles.js
+++ b/components/folder/IndividualFolder/styles.js
@@ -30,11 +30,6 @@ export const TitleContainer = styled.View`
   align-items: center;
 `;
 
-export const EditButton = styled.Image`
-  height: 20px;
-  width: 20px;
-`;
-
 export const FolderInitialElements = styled.View`
   width: ${windowWidth};
   height: 65px;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Only render edit folder icons when folder is selected/accordion is open
2. Rotate folder arrow icon when folder is selected/accordion is open

## Purpose
Edit icons only need to be displayed when a folder has been selected and the arrow indicators need to reflect that the folder has been opened by rotating.

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #88 