### PR TITLE
bug(folder-color-indicator): render folder color indicator from redux…

### DIFF
--- a/components/folder/AddFolderPage/AddFolderPage.js
+++ b/components/folder/AddFolderPage/AddFolderPage.js
@@ -42,12 +42,12 @@ import { addNewFolder } from "../../../redux/folderSlice";
 import { approvedColors } from "../../../utils/approvedColors";
 import BarcodeScanner from "../../BarcodeScanner/BarcodeScanner";
 import EditUrlModal from "../../EditUrlModal/EditUrlModal";
-import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 
 function AddFolderPage({ navigation }) {
   const [folderName, setFolderName] = useState(``);
   const [description, setDescription] = useState(``);
-  const [folderColor, setFolderColor] = useState(`red`);
+  const [folderColor, setFolderColor] = useState(`#FF453A`);
 
   const folderKeys = useSelector((state) =>
     Object.keys(state.folder.allFolder)
@@ -126,11 +126,11 @@ function AddFolderPage({ navigation }) {
         <AddedLinkWrapper key={link.id}>
           <AddedLinks>{link.name}</AddedLinks>
           <Pressable onPress={() => editButtonAction(link)} hitslop={10}>
-          <MaterialCommunityIcons
-                  name="pencil-outline"
-                  size={20}
-                  color="white"
-                />
+            <MaterialCommunityIcons
+              name="pencil-outline"
+              size={20}
+              color="white"
+            />
           </Pressable>
         </AddedLinkWrapper>
       );
@@ -162,8 +162,11 @@ function AddFolderPage({ navigation }) {
       <SafeAreaView style={{ backgroundColor: "#1c1d21" }}>
         <ScrollView>
           <Container>
-            <BackArrowContainer onPress={() => navigation.goBack()} hitslop={10}>
-            <Ionicons name="chevron-back" size={40} color="white" />
+            <BackArrowContainer
+              onPress={() => navigation.goBack()}
+              hitslop={10}
+            >
+              <Ionicons name="chevron-back" size={40} color="white" />
             </BackArrowContainer>
             <FolderTitleContainer>
               <FolderTitle>Add Folder</FolderTitle>

--- a/components/folder/EditFolderPage/EditFolderPage.js
+++ b/components/folder/EditFolderPage/EditFolderPage.js
@@ -1,9 +1,4 @@
-import {
-  ScrollView,
-  Alert,
-  Pressable,
-  SafeAreaView,
-} from "react-native";
+import { ScrollView, Alert, Pressable, SafeAreaView } from "react-native";
 import React, { useState, useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -54,7 +49,7 @@ import { deleteFolderToast } from "../../../utils/toastNote";
 import { approvedColors } from "../../../utils/approvedColors";
 import EditUrlModal from "../../EditUrlModal/EditUrlModal";
 import BarcodeScanner from "../../BarcodeScanner/BarcodeScanner";
-import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 
 import { resetQr } from "../../../redux/qrSlice";
 
@@ -79,7 +74,9 @@ function EditFolderPage({ navigation }) {
 
   const [folderName, setFolderName] = useState(``);
   const [description, setDescription] = useState(``);
-  const [folderColor, setFolderColor] = useState(`red`);
+  const [folderColor, setFolderColor] = useState(
+    `${currentFolder ? currentFolder.folderColor : "#FF453A"}`
+  );
 
   const [editNameInput, setEditNameInput] = useState(false);
   const [editDescriptionInput, setEditDescriptionInput] = useState(false);
@@ -156,8 +153,10 @@ function EditFolderPage({ navigation }) {
     if (currentFolder.folderColor === blobColor) {
       deleteAction();
       dispatch(resetQr());
-      //update blob color
+      // update blob color
       dispatch(setBlobColor("#5E5CE6"));
+      // update folder color to default
+      setFolderColor("#FF453A");
     } else {
       deleteAction();
     }
@@ -193,11 +192,11 @@ function EditFolderPage({ navigation }) {
         <AddedLinkWrapper key={link.id}>
           <AddedLinks>{link.name}</AddedLinks>
           <Pressable onPress={() => editButtonAction(link)} hitslop={10}>
-          <MaterialCommunityIcons
-                  name="pencil-outline"
-                  size={20}
-                  color="white"
-                />
+            <MaterialCommunityIcons
+              name="pencil-outline"
+              size={20}
+              color="white"
+            />
           </Pressable>
         </AddedLinkWrapper>
       );
@@ -231,8 +230,11 @@ function EditFolderPage({ navigation }) {
       <SafeAreaView style={{ backgroundColor: "#1c1d21" }}>
         <ScrollView>
           <Container>
-            <BackArrowContainer onPress={() => navigation.goBack()} hitslop={10}>
-            <Ionicons name="chevron-back" size={40} color="white" />
+            <BackArrowContainer
+              onPress={() => navigation.goBack()}
+              hitslop={10}
+            >
+              <Ionicons name="chevron-back" size={40} color="white" />
             </BackArrowContainer>
             <FolderTitleContainer>
               <FolderTitle>Edit Folder</FolderTitle>
@@ -251,12 +253,15 @@ function EditFolderPage({ navigation }) {
                   editable={editNameInput}
                   editMode={editNameInput}
                 />
-                <EditChange onPress={() => setEditNameInput(!editNameInput)} hitslop={10}>
-                <MaterialCommunityIcons
-                  name="pencil-outline"
-                  size={20}
-                  color="white"
-                />
+                <EditChange
+                  onPress={() => setEditNameInput(!editNameInput)}
+                  hitslop={10}
+                >
+                  <MaterialCommunityIcons
+                    name="pencil-outline"
+                    size={20}
+                    color="white"
+                  />
                 </EditChange>
               </InputContainer>
             </FolderInputSection>
@@ -281,10 +286,10 @@ function EditFolderPage({ navigation }) {
                   hitslop={10}
                 >
                   <MaterialCommunityIcons
-                  name="pencil-outline"
-                  size={20}
-                  color="white"
-                />
+                    name="pencil-outline"
+                    size={20}
+                    color="white"
+                  />
                 </EditChange>
               </InputContainer>
             </DescriptionSection>
@@ -320,9 +325,7 @@ function EditFolderPage({ navigation }) {
 
             <CreateCancelContainer>
               <CancelBtn onPress={() => deleteFolderHandler()}>
-                <CancelText >
-                  Delete
-                </CancelText>
+                <CancelText>Delete</CancelText>
               </CancelBtn>
               <CreateFolderBtn onPress={() => editSubmit()}>
                 <CreateText>Save</CreateText>


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Persist folder color indicator from redux
2. provide correct color for default folder color (from color picker pallete)

## Purpose
Editing folder would show a default red color on the indicator. 

Closes #99 